### PR TITLE
Temporary Fix for favorites profile error

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,10 +20,10 @@
 <div class="row">
   <% @user.favorites.each do |favorite| %>
       <div class="booyah-box col-10 offset-1">
-      <h5><%= link_to favorite.place.name, place_path(favorite.place) %></h5>
+      <h5><%= link_to favorite.place_id, place_path(favorite.place_id) %></h5>
       </div>
   <% end %>
-  </div> %>
+  </div>
 
 <br /><br />
 <h1 class="text-center">My Comments</h1>


### PR DESCRIPTION
Temporary fix for favorites throwing error when viewing profile page.

Instead of showing the Place name, it will now show the place id.
